### PR TITLE
Return the result from router.dispatch

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -68,7 +68,7 @@ class Router {
       if (result) {
         state.statusCode = typeof state.statusCode === 'number' ? state.statusCode : 200;
         cb(state, result);
-        return;
+        return result;
       }
     }
 
@@ -83,6 +83,8 @@ class Router {
         cb(state, result);
       }
     }
+
+    return result;
   }
 
 }

--- a/test/RoutingSpec.js
+++ b/test/RoutingSpec.js
@@ -37,6 +37,15 @@ describe('Routing', () => {
     expect(log).to.be.deep.equal([3, 2, 1]);
   });
 
+  it('Should return result', async () => {
+    const router = new Router(on => {
+      on('/test', async (state, next) => { return 3 + await next(); });
+      on('/test', async (state, next) => { return 2 + await next(); }, () => { return 1; });
+    });
+    const result = await router.dispatch('/test');
+    expect(result).to.be.equal(6);
+  });
+
   it('Should support async route handlers', async () => {
     const log = [];
     const router = new Router(on => {


### PR DESCRIPTION
Problem: the current router.dispatch API expects a callback method to provide the result.
So, following is not possible (which is cleaner than callback):

const component = await router.dispatch({ path: '/products/example' });
ReactDOM.render(component, document.getElementById('app'));

This commit:
- Modifies Router to return the result from dispatch method.
- Adds a test to verify the change.