### PR TITLE
fix typo: rotues -> routes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ server-side applications (e.g. Node.js/Express, Koa).
 ```js
 import { resolve } from 'universal-router';
 
-const rotues = [
+const routes = [
   {
     path: '/',
     action: () => `<h1>Home</h1>`


### PR DESCRIPTION
Fixes minor typo in documentation's example. 