### PR TITLE
Allow routes to return the result of context.end

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -46,7 +46,7 @@ async function resolve(routes, pathOrContext) {
   }
 
   context.next = next;
-  context.end = data => { result = data; done = true; };
+  context.end = data => { result = data; done = true; return data; };
 
   while (!done) {
     result = await next();


### PR DESCRIPTION
The proposed (tiny) change makes it slightly easier to return the results of a route that calls `context.end`

```
import UniversalRouter from 'universal-router';

// How it looks with the current codebase
const route = {
    path: '/foo',
    action: ctx => {
        // do something...
        const result = {
            foo: 'foo'
        };

        ctx.end(result);

        return Promise.resolve(result);
    }
};

// How it would look with the proposed changes
/*
const route = {
    path: '/foo',
    action: ctx => {
        // do something...
        return Promise.resolve(ctx.end({
            foo: 'foo'
        }));
    }
};
*/

UniversalRouter.resolve(
    {
        path: '/',
        children: [
            route
        ],
        action: ctx => {
            return ctx.next().then(result => {
                console.log(result); // { foo: 'foo' }
            });
        }
    },
    '/foo'
);
```