### PR TITLE
#45 Pass url while creating  404 error message

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -57,7 +57,7 @@ async function resolve(routes, pathOrContext) {
   }
 
   if (result === undefined && errorRoute) {
-    context.error = new Error(' Page ' + context.path + ' Not found ');
+    context.error = new Error(`Page ${context.path} Not found`);
     context.error.status = 404;
     return await errorRoute.action(context, {});
   }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -57,7 +57,7 @@ async function resolve(routes, pathOrContext) {
   }
 
   if (result === undefined && errorRoute) {
-    context.error = new Error('Not found');
+    context.error = new Error(' Page ' + context.path + ' Not found ');
     context.error.status = 404;
     return await errorRoute.action(context, {});
   }


### PR DESCRIPTION
Lets say I've received an 404 error in Universal router . And I'm trying to debug the Url that caused the error, I cant see the url as while creating the error we are not passing the URL