### PR TITLE
Remove errors handler from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Return `null` instead of `undefined` to signal no match ([#51](https://github.com/kriasoft/universal-router/pull/51))
 - Support `context.next()` across multiple routes ([#49](https://github.com/kriasoft/universal-router/pull/49))
 - Sequential execution of asynchronous routes ([#49](https://github.com/kriasoft/universal-router/pull/49))
+- Remove errors handler from core ([#48](https://github.com/kriasoft/universal-router/pull/48))
 - Drop support of node.js v5 and below ([#47](https://github.com/kriasoft/universal-router/pull/47))
 - Allow routes to return the result of `context.end()` ([#39](https://github.com/kriasoft/universal-router/pull/39))
 

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -18,7 +18,6 @@ async function resolve(routes, pathOrContext) {
   let value;
   let done = false;
 
-  const errorRoute = root.children && root.children.find(x => x.path === '/error');
   const match = matchRoute(root, '', context.path);
 
   async function next() {
@@ -30,18 +29,7 @@ async function resolve(routes, pathOrContext) {
 
     if (value.route.action) {
       const newContext = Object.assign({}, context, value);
-
-      if (errorRoute) {
-        try {
-          result = await value.route.action(newContext, newContext.params);
-        } catch (err) {
-          err.status = err.status || 500;
-          newContext.error = err;
-          result = await errorRoute.action(newContext, newContext.params);
-        }
-      } else {
-        result = await value.route.action(newContext, newContext.params);
-      }
+      result = await value.route.action(newContext, newContext.params);
     }
 
     return await next();

--- a/test/resolve.spec.js
+++ b/test/resolve.spec.js
@@ -217,24 +217,4 @@ describe('resolve(routes, { path, ...context })', () => {
     }
   });
 
-  it('should redirect to an error page if it exists', async () => {
-    const error = new Error('test error');
-    const action = sinon.spy(() => 'b');
-    const routes = [
-      {
-        path: '/a',
-        action() { throw error; },
-      },
-      {
-        path: '/error',
-        action,
-      },
-    ];
-
-    const result = await resolve(routes, '/a');
-    expect(result).to.be.equal('b');
-    expect(action.args[0][0]).to.have.property('error', error);
-    expect(action.args[0][0]).to.have.deep.property('error.status', 500);
-  });
-
 });


### PR DESCRIPTION
To handle the 404, add such route to the end:
```js
const routes = [
  // your routes here
  { path: '*', action() { return 'Page not found' } }
]
```

To handle any other errors, use try catch:
```js
try {
  await UniversalRouter.resolve(routes, '/path')
} catch (error) {
  // handle an error
}
```