### PR TITLE
Provide all URL parameters to each route

### DIFF
--- a/src/matchPath.js
+++ b/src/matchPath.js
@@ -28,7 +28,7 @@ function decodeParam(val) {
   }
 }
 
-function matchPathBase(end, routePath, urlPath) {
+function matchPathBase(end, routePath, urlPath, parentParams) {
   const key = `${routePath}|${end}`;
   let regexp = cache.get(key);
 
@@ -45,6 +45,10 @@ function matchPathBase(end, routePath, urlPath) {
   }
 
   const params = Object.create(null);
+  if (parentParams) {
+    Object.assign(params, parentParams);
+  }
+
   const path = m[0];
 
   for (let i = 1; i < m.length; i += 1) {

--- a/src/matchRoute.js
+++ b/src/matchRoute.js
@@ -9,11 +9,11 @@
 
 import { matchPath, matchBasePath } from './matchPath';
 
-function* matchRoute(route, baseUrl, path) {
+function* matchRoute(route, baseUrl, path, parentParams) {
   let match;
 
   if (!route.children) {
-    match = matchPath(route.path, path);
+    match = matchPath(route.path, path, parentParams);
 
     if (match) {
       yield {
@@ -27,7 +27,7 @@ function* matchRoute(route, baseUrl, path) {
   }
 
   if (route.children) {
-    match = matchBasePath(route.path, path);
+    match = matchBasePath(route.path, path, parentParams);
     if (match) {
       yield {
         route,
@@ -42,7 +42,8 @@ function* matchRoute(route, baseUrl, path) {
         yield* matchRoute(
           childRoute,
           baseUrl + (match.path === '/' ? '' : match.path),
-          newPath.startsWith('/') ? newPath : `/${newPath}`
+          newPath.startsWith('/') ? newPath : `/${newPath}`,
+          match.params
         );
       }
     }

--- a/test/resolve.spec.js
+++ b/test/resolve.spec.js
@@ -88,6 +88,53 @@ describe('resolve(routes, { path, ...context })', () => {
     expect(action.args[0][0]).to.have.deep.property('params.two', 'b');
   });
 
+  it('should provide all URL parameters to each route', async () => {
+    const action = sinon.spy();
+    const routes = [
+      {
+        path: '/:one',
+        children: [
+          {
+            path: '/:two',
+            action,
+          },
+        ],
+        action,
+      },
+    ];
+    await resolve(routes, { path: '/a/b' });
+    expect(action.calledTwice).to.be.true;
+    expect(action.args[0][0]).to.have.deep.property('params.one', 'a');
+    expect(action.args[1][0]).to.have.deep.property('params.one', 'a');
+    expect(action.args[1][0]).to.have.deep.property('params.two', 'b');
+  });
+
+  it('should override URL parameters with same name in child route', async () => {
+    const action = sinon.spy();
+    const routes = [
+      {
+        path: '/:one',
+        children: [
+          {
+            path: '/:one',
+            action,
+          },
+          {
+            path: '/:two',
+            action,
+          },
+        ],
+        action,
+      },
+    ];
+    await resolve(routes, { path: '/a/b' });
+    expect(action.calledThrice).to.be.true;
+    expect(action.args[0][0]).to.have.deep.property('params.one', 'a');
+    expect(action.args[1][0]).to.have.deep.property('params.one', 'b');
+    expect(action.args[2][0]).to.have.deep.property('params.one', 'a');
+    expect(action.args[2][0]).to.have.deep.property('params.two', 'b');
+  });
+
   it('should support next() across multiple routes', async () => {
     const log = [];
     const routes = [


### PR DESCRIPTION
Continued effort on #50

## Goal: Allow passing parameters from parent route to child routes

**Example:**
```js
const routes = {
  path: '/:articleId',
  children: [
    {
      path: '/',
      async action({ params }) {
        // can use params.articleId too!
      },
    },
    {
      path: '/edit',
      async action({ params }) {
        // can use params.articleId too!
      },
    },
  ],
  async action({ params }) {
    // can use params.articleId
  }
};
```

## TODO

- [ ] Decide how to enable this behavior in router
- [ ] Think more deeply if not inheriting params from parent routes should be default behavior
