### PR TITLE
Fixes eslint warning in build script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "^2.0.0-pre.3"
   },
   "scripts": {
-    "lint": "eslint src test",
+    "lint": "eslint src test tools",
     "test": "mocha --compilers js:babel-register",
     "test:watch": "mocha --compilers js:babel-register --reporter min --watch",
     "test:cover": "babel-node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha",

--- a/tools/build.js
+++ b/tools/build.js
@@ -84,7 +84,7 @@ let promise = Promise.resolve();
 promise = promise.then(() => del(['build/*']));
 
 // Compile source code into a distributable format with Babel
-for (const file of files) {
+files.forEach((file) => {
   promise = promise.then(() => rollup.rollup({
     entry: 'src/main.js',
     external: file.format === 'umd' ? [] : Object.keys(pkg.dependencies),
@@ -106,7 +106,7 @@ for (const file of files) {
     exports: 'named',
     moduleName: file.moduleName,
   })));
-}
+});
 
 // Copy package.json and LICENSE.txt
 promise = promise.then(() => {


### PR DESCRIPTION
Eslint was complaining about usage of `for...of` statement. 

This commit fixes this issue by refactoring it so that it uses Array.forEach.

My IDE was yelling at me, so I put stop to it.