### PR TITLE
Fixes links to getting-started and api in docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ import { resolve } from 'universal-router/legacy';
 
 ## Learn more
 
-* [Getting Started](./getting-started.md)
-* [Universal Router API](./api.md)
+* [Getting Started](./getting-started)
+* [Universal Router API](./api)
 
 
 ## Backers


### PR DESCRIPTION
The landing page has dead links to `getting-started` and `api` pages, they are routed to `https://www.kriasoft.com/universal-router/getting-started.md` and `https://www.kriasoft.com/universal-router/api.md` which throws a Github 404 error. 

Fixed it by routing it to `https://www.kriasoft.com/universal-router/getting-started` and `https://www.kriasoft.com/universal-router/api`