### PR TITLE
6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.0] - 2018-02-06
 
-- Add an option for global error handling ([#147](https://github.com/kriasoft/universal-router/pull/147))
+- No special configuration is required for your bundler anymore (say hi to [parcel.js](https://parceljs.org/)).
+- Add an option for global error handling ([#147](https://github.com/kriasoft/universal-router/pull/147)).
+
+**Migration from v5 to v6:**
+- Use `error.code` instead of `error.status` or `error.statusCode` for error handling.
 
 ## [5.1.0] - 2018-01-16
 
@@ -223,7 +227,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Small bug fixes and improvements
 
-[Unreleased]: https://github.com/kriasoft/universal-router/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/kriasoft/universal-router/compare/v6.0.0...HEAD
+[6.0.0]: https://github.com/kriasoft/universal-router/compare/v5.1.0...v6.0.0
 [5.1.0]: https://github.com/kriasoft/universal-router/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/kriasoft/universal-router/compare/v4.3.0...v5.0.0
 [4.3.0]: https://github.com/kriasoft/universal-router/compare/v4.2.1...v4.3.0

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ router.resolve('/posts').then(html => {
 })
 ```
 
-Play with an example on [JSFiddle](https://jsfiddle.net/frenzzy/b0w9mjck/84/),
-[CodePen](https://codepen.io/frenzzy/pen/aWLKpb/),
-[JS Bin](https://jsbin.com/kaluden/1/edit?js,output) in your browser or try
-[RunKit](https://runkit.com/frenzzy/universal-router-v4-demo) node.js playground.
+Play with an example on [JSFiddle](https://jsfiddle.net/frenzzy/b0w9mjck/102/),
+[CodePen](https://codepen.io/frenzzy/pen/aWLKpb?editors=0010),
+[JS Bin](https://jsbin.com/kaluden/3/edit?js,output) in your browser or try
+[RunKit](https://runkit.com/frenzzy/universal-router-demo) node.js playground.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "universal-router",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Isomorphic router for JavaScript web applications",
   "homepage": "https://www.kriasoft.com/universal-router/",
   "repository": "kriasoft/universal-router",
@@ -26,9 +26,9 @@
     "path-to-regexp": "^2.1.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.38",
-    "@babel/preset-env": "7.0.0-beta.38",
-    "@babel/register": "7.0.0-beta.38",
+    "@babel/core": "7.0.0-beta.39",
+    "@babel/preset-env": "7.0.0-beta.39",
+    "@babel/register": "7.0.0-beta.39",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "eslint": "^4.16.0",


### PR DESCRIPTION
- No special configuration is required for your bundler anymore (say hi to [parcel.js](https://parceljs.org/)).
- Add an option for global error handling ([#147](https://github.com/kriasoft/universal-router/pull/147)).

**Migration from v5 to v6:**
- Use `error.code` instead of `error.status` or `error.statusCode` for error handling.