### PR TITLE
Never mutate user errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,10 +4,12 @@
     "eslint-config-prettier"
   ],
   "rules": {
+    "guard-for-in": "off",
     "no-param-reassign": ["error", {
       "props": true,
       "ignorePropertyModificationsFor": ["router", "error"]
     }],
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "no-restricted-syntax": "off"
   }
 }

--- a/src/UniversalRouter.js
+++ b/src/UniversalRouter.js
@@ -94,7 +94,17 @@ class UniversalRouter {
 
     return Promise.resolve()
       .then(() => next(true, this.root))
-      .catch((error) => {
+      .catch((err) => {
+        const error = new Error(err)
+        if (err instanceof Error) {
+          try {
+            const props = Object.getOwnPropertyDescriptors(err)
+            for (const key in props) Object.defineProperty(error, key, props[key])
+            Object.setPrototypeOf(error, Object.getPrototypeOf(err))
+          } catch (e) {
+            // ignore
+          }
+        }
         error.context = error.context || currentContext
         error.code = error.code || 500
         if (this.errorHandler) {


### PR DESCRIPTION
Some libraries freezes an error object before rejection (`Object.freeze(err)`). Because code which adds `context` and `code` to the error object throws an exception, the router unable to call error handler and some exceptions may become unhandled.

Solution: never mutate third-party error object.

ref #152