### PR TITLE
Catch any rejections using errorHandler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ but depending on your target browsers you may need to include
 before any other code.
 
 For compatibility with older browsers you may also need to include polyfills for
-[`Array.isArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
-and [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create).
+[`Array.isArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray),
+[`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) and
+[`Object.isExtensible`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible).
 
 ## Contributing
 

--- a/src/UniversalRouter.js
+++ b/src/UniversalRouter.js
@@ -10,6 +10,8 @@
 import pathToRegexp from 'path-to-regexp'
 import matchRoute from './matchRoute'
 
+const { isExtensible } = Object
+
 function resolveRoute(context, params) {
   if (typeof context.route.action === 'function') {
     return context.route.action(context, params)
@@ -94,7 +96,8 @@ class UniversalRouter {
 
     return Promise.resolve()
       .then(() => next(true, this.root))
-      .catch((error) => {
+      .catch((err) => {
+        const error = err instanceof Error && isExtensible(err) ? err : new Error(err)
         error.context = error.context || currentContext
         error.code = error.code || 500
         if (this.errorHandler) {

--- a/test/UniversalRouter.test.js
+++ b/test/UniversalRouter.test.js
@@ -57,7 +57,7 @@ describe('new UniversalRouter(routes, options)', () => {
     const route = {
       path: '/',
       action: () => {
-        throw new Error('custom')
+        throw Object.freeze(new Error('custom'))
       },
     }
     const router = new UniversalRouter(route, { errorHandler })
@@ -66,7 +66,7 @@ describe('new UniversalRouter(routes, options)', () => {
     expect(errorHandler.mock.calls.length).toBe(1)
     const error = errorHandler.mock.calls[0][0]
     expect(error).toBeInstanceOf(Error)
-    expect(error.message).toBe('custom')
+    expect(error.message).toContain('custom')
     expect(error.code).toBe(500)
     expect(error.context.pathname).toBe('/')
     expect(error.context.path).toBe('/')
@@ -514,6 +514,28 @@ describe('router.resolve({ pathname, ...context })', () => {
       err = e
     }
     expect(err).toBe(error)
+    expect(err.code).toBe(500)
+  })
+
+  it('should always reject with Error object', async () => {
+    const error = 'test error'
+    const router = new UniversalRouter([
+      {
+        path: '/a',
+        action() {
+          throw error
+        },
+      },
+    ])
+    let err
+    try {
+      await router.resolve('/a')
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toBe(error)
+    expect(err.code).toBe(500)
   })
 
   it('should respect baseUrl', async () => {


### PR DESCRIPTION
Alternative solution for #154 and #152 

If your or third-party code calls `Promise.reject(nonErrorObject)` router will wrap up the result into Error object and call errorHandler anyway.