### PR TITLE
Error handler with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [BREAKING] The router no longer mutates errors to avoid issues with non-extensible objects.
+  ([#158](https://github.com/kriasoft/universal-router/pull/158)).
+
+**Migration from v6 to v7:**
+- If your code relies on `error.context` or `error.code` you still can access the same variables using `errorHandler` option:
+  ```js
+  errorHandler(error, context) {
+    const code = error.message === 'Route not found' ? 404 : 500
+    console.log(error, context, code)
+  }
+  ```
+
 ## [6.0.0] - 2018-02-06
 
 - No special configuration is required for your bundler anymore (say hi to [parcel.js](https://parceljs.org/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- [BREAKING] The router no longer mutates errors to avoid issues with non-extensible objects.
-  ([#158](https://github.com/kriasoft/universal-router/pull/158)).
+- The router no longer mutate errors to avoid issues with non-extensible objects.
+  (BREAKING CHANGE [#158](https://github.com/kriasoft/universal-router/pull/158)).
 
 **Migration from v6 to v7:**
-- If your code relies on `error.context` or `error.code` you still can access the same variables using `errorHandler` option:
+- If your code relies on `error.context` or `error.code` you still can access them
+  using `errorHandler` option:
   ```js
   errorHandler(error, context) {
-    const code = error.message === 'Route not found' ? 404 : 500
+    const code = error.status || 500
     console.log(error, context, code)
   }
   ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ const options = {
   errorHandler(error, context) {
     console.error(error)
     console.info(context)
-    return error.message === 'Route not found'
+    return error.status === 404
       ? '<h1>Page Not Found</h1>'
       : '<h1>Oops! Something went wrong</h1>'
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,11 +15,9 @@ Second `options` argument is optional where you can pass the following:
 * `resolveRoute` - function for any custom route handling logic.\
   For example you can define this option to work with routes in declarative manner.\
   By default the router calls the `action` method of matched route.
-* `errorHandler` - function for global error handling. Called with a single
-  [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) 
-  argument every time the route is not found or threw an error which always contain
-  [http status `code`](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) and
-  [current `context`](#context) for your convenience.
+* `errorHandler` - function for global error handling. Called with an
+  [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+  and [Context](#context) arguments every time the route is not found or threw an error.
 
 ```js
 import UniversalRouter from 'universal-router'
@@ -47,10 +45,10 @@ const options = {
     }
     return undefined
   },
-  errorHandler(error) {
+  errorHandler(error, context) {
     console.error(error)
-    console.dir(error.context)
-    return error.code === 404
+    console.info(context)
+    return error.message === 'Route not found'
       ? '<h1>Page Not Found</h1>'
       : '<h1>Oops! Something went wrong</h1>'
   }

--- a/src/UniversalRouter.js
+++ b/src/UniversalRouter.js
@@ -10,8 +10,6 @@
 import pathToRegexp from 'path-to-regexp'
 import matchRoute from './matchRoute'
 
-const notFound = 'Route not found'
-
 function resolveRoute(context, params) {
   if (typeof context.route.action === 'function') {
     return context.route.action(context, params)
@@ -76,7 +74,9 @@ class UniversalRouter {
       }
 
       if (matches.done) {
-        return Promise.reject(new Error(notFound))
+        const error = new Error('Route not found')
+        error.status = 404
+        return Promise.reject(error)
       }
 
       currentContext = { ...context, ...matches.value }

--- a/src/UniversalRouter.js
+++ b/src/UniversalRouter.js
@@ -10,6 +10,8 @@
 import pathToRegexp from 'path-to-regexp'
 import matchRoute from './matchRoute'
 
+const notFound = 'Route not found'
+
 function resolveRoute(context, params) {
   if (typeof context.route.action === 'function') {
     return context.route.action(context, params)
@@ -74,10 +76,7 @@ class UniversalRouter {
       }
 
       if (matches.done) {
-        const error = new Error('Page not found')
-        error.context = context
-        error.code = 404
-        return Promise.reject(error)
+        return Promise.reject(new Error(notFound))
       }
 
       currentContext = { ...context, ...matches.value }
@@ -95,10 +94,8 @@ class UniversalRouter {
     return Promise.resolve()
       .then(() => next(true, this.root))
       .catch((error) => {
-        error.context = error.context || currentContext
-        error.code = error.code || 500
         if (this.errorHandler) {
-          return this.errorHandler(error)
+          return this.errorHandler(error, currentContext)
         }
         throw error
       })

--- a/test/UniversalRouter.test.js
+++ b/test/UniversalRouter.test.js
@@ -47,6 +47,7 @@ describe('new UniversalRouter(routes, options)', () => {
     const context = errorHandler.mock.calls[0][1]
     expect(error).toBeInstanceOf(Error)
     expect(error.message).toBe('Route not found')
+    expect(error.status).toBe(404)
     expect(context.pathname).toBe('/')
     expect(context.router).toBe(router)
   })
@@ -85,6 +86,7 @@ describe('router.resolve({ pathname, ...context })', () => {
     }
     expect(err).toBeInstanceOf(Error)
     expect(err.message).toBe('Route not found')
+    expect(err.status).toBe(404)
   })
 
   it("should execute the matching route's action method and return its result", async () => {
@@ -136,6 +138,7 @@ describe('router.resolve({ pathname, ...context })', () => {
     }
     expect(err).toBeInstanceOf(Error)
     expect(err.message).toBe('Route not found')
+    expect(err.status).toBe(404)
     expect(action.mock.calls.length).toBe(0)
   })
 
@@ -540,6 +543,7 @@ describe('router.resolve({ pathname, ...context })', () => {
     expect(action.mock.calls.length).toBe(1)
     expect(err).toBeInstanceOf(Error)
     expect(err.message).toBe('Route not found')
+    expect(err.status).toBe(404)
   })
 
   it('should match routes with trailing slashes', async () => {

--- a/test/UniversalRouter.test.js
+++ b/test/UniversalRouter.test.js
@@ -44,12 +44,11 @@ describe('new UniversalRouter(routes, options)', () => {
     expect(result).toBe('result')
     expect(errorHandler.mock.calls.length).toBe(1)
     const error = errorHandler.mock.calls[0][0]
+    const context = errorHandler.mock.calls[0][1]
     expect(error).toBeInstanceOf(Error)
-    expect(error.message).toBe('Page not found')
-    expect(error.code).toBe(404)
-    expect(error.context.pathname).toBe('/')
-    expect(error.context.path).toBe(undefined)
-    expect(error.context.router).toBe(router)
+    expect(error.message).toBe('Route not found')
+    expect(context.pathname).toBe('/')
+    expect(context.router).toBe(router)
   })
 
   it('should handle route errors', async () => {
@@ -65,13 +64,13 @@ describe('new UniversalRouter(routes, options)', () => {
     expect(result).toBe('result')
     expect(errorHandler.mock.calls.length).toBe(1)
     const error = errorHandler.mock.calls[0][0]
+    const context = errorHandler.mock.calls[0][1]
     expect(error).toBeInstanceOf(Error)
     expect(error.message).toBe('custom')
-    expect(error.code).toBe(500)
-    expect(error.context.pathname).toBe('/')
-    expect(error.context.path).toBe('/')
-    expect(error.context.router).toBe(router)
-    expect(error.context.route).toBe(route)
+    expect(context.pathname).toBe('/')
+    expect(context.path).toBe('/')
+    expect(context.router).toBe(router)
+    expect(context.route).toBe(route)
   })
 })
 
@@ -85,11 +84,7 @@ describe('router.resolve({ pathname, ...context })', () => {
       err = e
     }
     expect(err).toBeInstanceOf(Error)
-    expect(err.message).toBe('Page not found')
-    expect(err.code).toBe(404)
-    expect(err.context.pathname).toBe('/')
-    expect(err.context.path).toBe(undefined)
-    expect(err.context.router).toBe(router)
+    expect(err.message).toBe('Route not found')
   })
 
   it("should execute the matching route's action method and return its result", async () => {
@@ -140,8 +135,7 @@ describe('router.resolve({ pathname, ...context })', () => {
       err = e
     }
     expect(err).toBeInstanceOf(Error)
-    expect(err.message).toBe('Page not found')
-    expect(err.code).toBe(404)
+    expect(err.message).toBe('Route not found')
     expect(action.mock.calls.length).toBe(0)
   })
 
@@ -545,11 +539,7 @@ describe('router.resolve({ pathname, ...context })', () => {
     }
     expect(action.mock.calls.length).toBe(1)
     expect(err).toBeInstanceOf(Error)
-    expect(err.message).toBe('Page not found')
-    expect(err.code).toBe(404)
-    expect(err.context.pathname).toBe('/a/b/c')
-    expect(err.context.path).toBe(undefined)
-    expect(err.context.router).toBe(router)
+    expect(err.message).toBe('Route not found')
   })
 
   it('should match routes with trailing slashes', async () => {


### PR DESCRIPTION
The router no longer mutate errors to avoid issues with non-extensible objects.
If your code relies on `error.context` or `error.code` you still can access the same variables using `errorHandler` option:
```js
errorHandler(error, context) {
  const code = error.status || 500
  console.log(error, context, code)
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

Closes #152 
Closes #154 
Closes #156