### PR TITLE
Remove unused `params` param  in resolveRedirect example

### DIFF
--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -102,7 +102,7 @@ const routes = [
 ]
 
 const router = new UniversalRouter(routes, {
-  resolveRoute(context, params) {
+  resolveRoute(context) {
     if (context.route.protected && !context.user) {
       return { redirect: '/login', from: context.pathname } // <== where the redirect come from?
     }


### PR DESCRIPTION
Why is it there? The [docs](https://github.com/kriasoft/universal-router/blob/main/docs/api.md#context) say `params` is part of `context` object. In any case it is unused in the example.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
