### PR TITLE
add "empty list as catch-all" behavior to API docs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -110,6 +110,23 @@ router.resolve({ pathname: '/admin/users/john' })
   // => User Profile
 ```
 
+Setting the `children` property to an empty list will act as a catch-all capture all routes beneath that path
+
+```js
+const router = new UniversalRouter({
+  path: '/admin',
+  children: [],
+  action: () => 'Admin Page'
+})
+
+router.resolve({ pathname: '/admin/users/john' })
+  .then(result => console.log(result))
+  // => Admin Page
+router.resolve({ pathname: '/admin/some/other/page' })
+  .then(result => console.log(result))
+  // => Admin Page
+```
+
 ## URL Parameters
 
 **Named route parameters** are captured and added to `context.params`.


### PR DESCRIPTION
Documented the usecase where an empty list passed to the `children` property of a route acts as a catch-all.

Source: https://gitter.im/kriasoft/universal-router?at=616713298c019f0d0b32350e


It might be useful to test the code examples since i mostly just guessed at what the return values would be instead of actually testing them.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
