### PR TITLE
Enable noPropertyAccessFromIndexSignature and noUncheckedIndexedAccess

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['airbnb-base', 'plugin:jest/recommended', 'plugin:prettier/recommended'],
   rules: {
+    'dot-notation': 'off',
     'no-nested-ternary': 'off',
     'no-param-reassign': [
       'error',
@@ -26,6 +27,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
         'import/extensions': [
           'error',
           'ignorePackages',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --force
     - name: Lint
       run: npm run lint
     - name: Test

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts,.js",
     "test": "jest",
-    "build": "node tools/build.js"
+    "build": "node tools/build.js",
+    "tsc": "tsc --noEmit"
   }
 }

--- a/src/UniversalRouter.test.ts
+++ b/src/UniversalRouter.test.ts
@@ -514,7 +514,7 @@ test('respects baseUrl', async () => {
   expect(action.mock.calls[0][0]).toHaveProperty('pathname', '/base/a/b/c')
   expect(action.mock.calls[0][0]).toHaveProperty('path', '/c')
   expect(action.mock.calls[0][0]).toHaveProperty('baseUrl', '/base/a/b')
-  expect(action.mock.calls[0][0]).toHaveProperty('route', routes.children[0].children[0])
+  expect(action.mock.calls[0][0]).toHaveProperty('route', routes.children[0]?.children[0])
   expect(action.mock.calls[0][0]).toHaveProperty('router', router)
 
   let err

--- a/src/UniversalRouter.ts
+++ b/src/UniversalRouter.ts
@@ -190,7 +190,7 @@ function matchRoute<R, C extends RouterContext>(
       if (matchResult && route.children) {
         while (childIndex < route.children.length) {
           if (!childMatches) {
-            const childRoute = route.children[childIndex]
+            const childRoute = route.children[childIndex]!
             childRoute.parent = route
 
             childMatches = matchRoute<R, C>(
@@ -320,7 +320,7 @@ class UniversalRouter<R = any, C extends RouterContext = RouterContext> {
       })
     }
 
-    context.next = next
+    context['next'] = next
 
     return Promise.resolve()
       .then(() => next(true, this.root))

--- a/src/UniversalRouterSync.test.ts
+++ b/src/UniversalRouterSync.test.ts
@@ -511,7 +511,7 @@ test('respects baseUrl', () => {
   expect(action.mock.calls[0][0]).toHaveProperty('pathname', '/base/a/b/c')
   expect(action.mock.calls[0][0]).toHaveProperty('path', '/c')
   expect(action.mock.calls[0][0]).toHaveProperty('baseUrl', '/base/a/b')
-  expect(action.mock.calls[0][0]).toHaveProperty('route', routes.children[0].children[0])
+  expect(action.mock.calls[0][0]).toHaveProperty('route', routes.children[0]?.children[0])
   expect(action.mock.calls[0][0]).toHaveProperty('router', router)
 
   let err

--- a/src/UniversalRouterSync.ts
+++ b/src/UniversalRouterSync.ts
@@ -191,7 +191,7 @@ function matchRoute<R, C extends RouterContext>(
       if (matchResult && route.children) {
         while (childIndex < route.children.length) {
           if (!childMatches) {
-            const childRoute = route.children[childIndex]
+            const childRoute = route.children[childIndex]!
             childRoute.parent = route
 
             childMatches = matchRoute<R, C>(
@@ -318,7 +318,7 @@ class UniversalRouterSync<R = any, C extends RouterContext = RouterContext> {
       return next(resume, parent, result)
     }
 
-    context.next = next
+    context['next'] = next
 
     try {
       return next(true, this.root)

--- a/src/generateUrls.ts
+++ b/src/generateUrls.ts
@@ -57,7 +57,7 @@ function cacheRoutes(
 
   if (routes) {
     for (let i = 0; i < routes.length; i++) {
-      const childRoute = routes[i]
+      const childRoute = routes[i]!
       const childName = childRoute.name
       childRoute.parent = route
       cacheRoutes(
@@ -117,7 +117,7 @@ function generateUrls(router: UniversalRouter, options?: GenerateUrlsOptions): G
       const keys: Keys = Object.create(null)
       for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i]
-        if (typeof token !== 'string') {
+        if (token && typeof token !== 'string') {
           keys[token.name] = true
         }
       }
@@ -132,8 +132,8 @@ function generateUrls(router: UniversalRouter, options?: GenerateUrlsOptions): G
       const keys = Object.keys(params)
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i]
-        if (!regexp.keys[key]) {
-          queryParams[key] = params[key]
+        if (key && !regexp.keys[key]) {
+          queryParams[key] = params[key] ?? ''
         }
       }
       const query = opts.stringifyQueryParams(queryParams)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "strict": true,
     "declaration": true,
     "noEmitOnError": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,


### PR DESCRIPTION
## Types of changes

We want to have these two typescript checks on:

- noPropertyAccessFromIndexSignature
- noUncheckedIndexedAccess

But our project won't typecheck because of errors in universal routes.
Apparently it is not possible to ignore these errors using `exclude` or `ignoreLibChecks`.
See https://github.com/microsoft/TypeScript/issues/44205#issuecomment-849895090

- [x ] Bug fix (non-breaking change which fixes an issue)

This fixes the errors here.

## Checklist:

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
