### PR TITLE
feat: add TypeScript type inference for route parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Join **[#universal-router](https://gitter.im/kriasoft/universal-router)** on Git
 - Routes are plain JavaScript
   [objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
   with which you can interact as you like.
+- It provides [type-safe route definitions](https://github.com/kriasoft/universal-router/blob/master/docs/api.md#type-safe-routes)
+  with automatic path parameter inference for TypeScript users.
 
 ## What users say about Universal Router
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -430,6 +430,62 @@ url('users.list') // => /users/list
 url('pages.list') // => /pages/list
 ```
 
+## Type-Safe Routes
+
+Type-safe URL generation catches errors at compile time. Use `as const` on your route
+definitions to enable automatic type inference.
+
+```ts
+import UniversalRouter from 'universal-router'
+import generateUrls from 'universal-router/generate-urls'
+
+// Define routes with `as const` for type inference
+const routes = [
+  { path: '/users/:userId', name: 'user' },
+  { path: '/posts/:postId', name: 'post' },
+] as const
+
+const router = new UniversalRouter(routes)
+const url = generateUrls(router)
+
+// Type-safe: autocomplete for names, validated params
+url('user', { userId: '123' }) // OK: '/users/123'
+url('user', {}) // Error: missing userId
+url('typo', {}) // Error: invalid route name
+```
+
+### Optional: `defineRoute` for Typed Actions
+
+Use `defineRoute` when you need typed params in action functions:
+
+```ts
+import UniversalRouter, { defineRoute } from 'universal-router'
+
+const route = defineRoute({
+  path: '/users/:userId',
+  name: 'user',
+  action: (ctx, params) => {
+    // params.userId is typed as string
+    return fetchUser(params.userId)
+  },
+})
+```
+
+### Extract Params from Any Path
+
+```ts
+import type { ExtractParams } from 'universal-router'
+
+type Params = ExtractParams<'/api/:version/*rest'>
+// { version: string; rest: string[] }
+```
+
+### Notes
+
+- Use `as const` on route arrays for type inference
+- Dynamic routes added at runtime are not type-checked
+- TypeScript 5.0+ recommended
+
 ## Recipes
 
 - [Redirects](https://github.com/kriasoft/universal-router/blob/master/docs/redirects.md)

--- a/src/generate-urls.test.ts
+++ b/src/generate-urls.test.ts
@@ -7,10 +7,13 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import { describe, test, expect, vi, type Mock } from 'vitest'
+import { describe, test, expect, vi, expectTypeOf, type Mock } from 'vitest'
 import UniversalRouter from './universal-router'
 import UniversalRouterSync from './universal-router-sync'
-import generateUrls from './generate-urls'
+import generateUrls, {
+  type ExtractRouteNames,
+  type ExtractRoutePaths,
+} from './generate-urls'
 import { parse } from './path-to-regexp'
 
 describe('generateUrls', () => {
@@ -278,5 +281,125 @@ describe('generateUrls', () => {
     const router = new UniversalRouter({ path: '/{foo}', name: 'group' })
     const url = generateUrls(router)
     expect(url('group')).toBe('/foo')
+  })
+})
+
+describe('Type-Safe URL Generation', () => {
+  describe('generateUrls infers types from router', () => {
+    test('infers route names from router with as const routes', () => {
+      const routes = [
+        { path: '/users/:userId', name: 'user' },
+        { path: '/posts/:postId', name: 'post' },
+      ] as const
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      expect(url('user', { userId: '123' })).toBe('/users/123')
+      expect(url('post', { postId: '456' })).toBe('/posts/456')
+    })
+
+    test('infers params requirements from router', () => {
+      const routes = [
+        { path: '/users/:userId', name: 'user' },
+        { path: '/about', name: 'about' },
+      ] as const
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      const userUrl: string = url('user', { userId: '123' })
+      expect(userUrl).toBe('/users/123')
+
+      const aboutUrl: string = url('about')
+      expect(aboutUrl).toBe('/about')
+    })
+
+    test('works with nested routes and separator', () => {
+      const routes = [
+        {
+          path: '/api',
+          name: 'api',
+          children: [
+            { path: '/users/:userId', name: 'users' },
+            { path: '/posts/:postId', name: 'posts' },
+          ],
+        },
+      ]
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router, { uniqueRouteNameSep: '.' })
+
+      expect(url('api.users', { userId: '123' })).toBe('/api/users/123')
+      expect(url('api.posts', { postId: '456' })).toBe('/api/posts/456')
+    })
+
+    test('works with wildcard params', () => {
+      const routes = [{ path: '/files/*path', name: 'files' }] as const
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      expect(url('files', { path: ['docs', 'readme.md'] })).toBe(
+        '/files/docs/readme.md',
+      )
+    })
+
+    test('works with baseUrl option', () => {
+      const routes = [{ path: '/users/:userId', name: 'user' }] as const
+
+      const router = new UniversalRouter(routes, { baseUrl: '/app' })
+      const url = generateUrls(router)
+
+      expect(url('user', { userId: '123' })).toBe('/app/users/123')
+    })
+
+    test('type checking validates route names', () => {
+      const routes = [
+        { path: '/users', name: 'users' },
+        { path: '/posts', name: 'posts' },
+      ] as const
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      const usersUrl: string = url('users')
+      const postsUrl: string = url('posts')
+      expectTypeOf(usersUrl).toBeString()
+      expectTypeOf(postsUrl).toBeString()
+
+      type RouteNames = ExtractRouteNames<typeof routes>
+      expectTypeOf<'users'>().toExtend<RouteNames>()
+      expectTypeOf<'posts'>().toExtend<RouteNames>()
+
+      type RoutePaths = ExtractRoutePaths<typeof routes>
+      expectTypeOf<'/users'>().toExtend<RoutePaths>()
+      expectTypeOf<'/posts'>().toExtend<RoutePaths>()
+    })
+
+    test('type checking validates params', () => {
+      const routes = [{ path: '/users/:userId', name: 'user' }] as const
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      const result: string = url('user', { userId: '123' })
+      expectTypeOf(result).toBeString()
+    })
+  })
+
+  describe('backwards compatibility', () => {
+    test('untyped routes still work (no as const)', () => {
+      const routes = [
+        { path: '/users/:userId', name: 'user' },
+        { path: '/posts/:postId', name: 'post' },
+      ]
+
+      const router = new UniversalRouter(routes)
+      const url = generateUrls(router)
+
+      expect(url('user', { userId: '123' })).toBe('/users/123')
+      expect(url('post', { postId: '456' })).toBe('/posts/456')
+    })
   })
 })

--- a/src/generate-urls.ts
+++ b/src/generate-urls.ts
@@ -9,26 +9,223 @@
 
 import type { ParseOptions, CompileOptions } from './path-to-regexp.js'
 import { parse, compile, stringify, TokenData } from './path-to-regexp.js'
-import UniversalRouter, { Route, Routes } from './universal-router.js'
+import UniversalRouter, {
+  Route,
+  Routes,
+  RouterContext,
+  Prettify,
+  EmptyParams,
+  ExtractParams,
+} from './universal-router.js'
 
+/** Parameters for URL generation, including path params and query params */
 export interface UrlParams {
   [paramName: string]: string | string[]
 }
 
+type IsEmptyObject<T> = keyof T extends never ? true : false
+
+/**
+ * Extracts all route names from route definitions as a union type.
+ * @example
+ * const routes = [{ name: 'home' }, { name: 'users' }] as const
+ * type Names = ExtractRouteNames<typeof routes> // 'home' | 'users'
+ */
+export type ExtractRouteNames<
+  Routes extends readonly unknown[],
+  Prefix extends string = '',
+  Sep extends string = '',
+> = Routes extends readonly [infer First, ...infer Rest]
+  ? First extends { name: infer N extends string }
+    ? First extends { children: infer C extends readonly unknown[] }
+      ? // Route with name and children
+        // When Sep is empty, don't prefix children (they use their own names)
+        // When Sep is non-empty, prefix children with parent name + sep
+        Sep extends ''
+        ?
+            | N
+            | ExtractRouteNames<C, '', Sep>
+            | ExtractRouteNames<Rest, Prefix, Sep>
+        :
+            | (Prefix extends '' ? N : `${Prefix}${Sep}${N}`)
+            | ExtractRouteNames<
+                C,
+                Prefix extends '' ? N : `${Prefix}${Sep}${N}`,
+                Sep
+              >
+            | ExtractRouteNames<Rest, Prefix, Sep>
+      : // Route with name, no children
+        Sep extends ''
+        ? N | ExtractRouteNames<Rest, Prefix, Sep>
+        :
+            | (Prefix extends '' ? N : `${Prefix}${Sep}${N}`)
+            | ExtractRouteNames<Rest, Prefix, Sep>
+    : First extends { children: infer C extends readonly unknown[] }
+      ? // Route without name but with children - use parent prefix
+          | ExtractRouteNames<C, Prefix, Sep>
+          | ExtractRouteNames<Rest, Prefix, Sep>
+      : // Route without name or children
+        ExtractRouteNames<Rest, Prefix, Sep>
+  : never
+
+/** Extracts first path from array or returns path if string */
+type FirstPath<P> = P extends readonly [
+  infer First extends string,
+  ...unknown[],
+]
+  ? First
+  : P extends string
+    ? P
+    : never
+
+/** Extracts all full paths from route definitions, including nested routes */
+export type ExtractRoutePaths<
+  Routes extends readonly unknown[],
+  ParentPath extends string = '',
+> = Routes extends readonly [infer First, ...infer Rest]
+  ? First extends { path: infer P }
+    ? FirstPath<P> extends infer FP extends string
+      ? First extends { children: infer C extends readonly unknown[] }
+        ? // Route with children - include own path and recurse
+            | `${ParentPath}${FP}`
+            | ExtractRoutePaths<C, `${ParentPath}${FP}`>
+            | ExtractRoutePaths<Rest, ParentPath>
+        : // Route without children
+            `${ParentPath}${FP}` | ExtractRoutePaths<Rest, ParentPath>
+      : // Path doesn't resolve to string - skip
+        ExtractRoutePaths<Rest, ParentPath>
+    : // No path property - skip to rest
+      ExtractRoutePaths<Rest, ParentPath>
+  : never
+
+/** Maps a route name to its full path, accumulating parent paths for nested routes */
+export type RouteNameToFullPath<
+  Routes extends readonly unknown[],
+  Name extends string,
+  ParentPath extends string = '',
+  ParentNamePrefix extends string = '',
+  Sep extends string = '',
+> = Routes extends readonly [infer First, ...infer Rest]
+  ? First extends { path: infer P }
+    ? FirstPath<P> extends infer FP extends string
+      ? First extends { name: infer N extends string }
+        ? Sep extends ''
+          ? // When Sep is empty, names are independent - just match N directly
+            N extends Name
+            ? `${ParentPath}${FP}`
+            : First extends { children: infer C extends readonly unknown[] }
+              ? // Check children, passing accumulated path but NOT name prefix
+                  | RouteNameToFullPath<C, Name, `${ParentPath}${FP}`, '', Sep>
+                  | RouteNameToFullPath<Rest, Name, ParentPath, '', Sep>
+              : RouteNameToFullPath<Rest, Name, ParentPath, '', Sep>
+          : // When Sep is non-empty, build the full name with prefix
+            (
+                ParentNamePrefix extends ''
+                  ? N
+                  : `${ParentNamePrefix}${Sep}${N}`
+              ) extends Name
+            ? // Found it - return accumulated path + this route's path
+              `${ParentPath}${FP}`
+            : First extends { children: infer C extends readonly unknown[] }
+              ? // Check children with updated path and name prefix
+                  | RouteNameToFullPath<
+                      C,
+                      Name,
+                      `${ParentPath}${FP}`,
+                      ParentNamePrefix extends ''
+                        ? N
+                        : `${ParentNamePrefix}${Sep}${N}`,
+                      Sep
+                    >
+                  | RouteNameToFullPath<
+                      Rest,
+                      Name,
+                      ParentPath,
+                      ParentNamePrefix,
+                      Sep
+                    >
+              : // No children, check rest
+                RouteNameToFullPath<
+                  Rest,
+                  Name,
+                  ParentPath,
+                  ParentNamePrefix,
+                  Sep
+                >
+        : First extends { children: infer C extends readonly unknown[] }
+          ? // No name but has children - continue with accumulated path, keep same prefix
+              | RouteNameToFullPath<
+                  C,
+                  Name,
+                  `${ParentPath}${FP}`,
+                  ParentNamePrefix,
+                  Sep
+                >
+              | RouteNameToFullPath<
+                  Rest,
+                  Name,
+                  ParentPath,
+                  ParentNamePrefix,
+                  Sep
+                >
+          : // No name, no children - check rest
+            RouteNameToFullPath<Rest, Name, ParentPath, ParentNamePrefix, Sep>
+      : // Path doesn't resolve to string - skip to rest
+        RouteNameToFullPath<Rest, Name, ParentPath, ParentNamePrefix, Sep>
+    : // No path property - skip to rest
+      RouteNameToFullPath<Rest, Name, ParentPath, ParentNamePrefix, Sep>
+  : never
+
+/**
+ * Maps a route name to its required parameters based on the full path.
+ * @example
+ * const routes = [{ name: 'user', path: '/users/:id' }] as const
+ * type Params = RouteNameToParams<typeof routes, 'user'> // { id: string }
+ */
+export type RouteNameToParams<
+  Routes extends readonly unknown[],
+  Name extends string,
+  Sep extends string = '',
+> =
+  RouteNameToFullPath<Routes, Name, '', '', Sep> extends infer Path
+    ? Path extends string
+      ? Prettify<ExtractParams<Path>>
+      : EmptyParams
+    : EmptyParams
+
+/**
+ * Type-safe URL generator function signature.
+ * Enforces correct route names and required parameters at compile time.
+ */
+export type TypedGenerateUrl<
+  Routes extends readonly unknown[],
+  Sep extends string = '',
+> = <Name extends ExtractRouteNames<Routes, '', Sep>>(
+  routeName: Name,
+  ...args: IsEmptyObject<RouteNameToParams<Routes, Name, Sep>> extends true
+    ? [params?: Record<string, string | string[]>]
+    : [
+        params: RouteNameToParams<Routes, Name, Sep> &
+          Record<string, string | string[]>,
+      ]
+) => string
+
+/** Options for generateUrls() with typed separator for hierarchical route names */
+export interface TypedGenerateUrlsOptions<Sep extends string = ''> extends Omit<
+  GenerateUrlsOptions,
+  'uniqueRouteNameSep'
+> {
+  uniqueRouteNameSep?: Sep
+}
+
+/** Options for URL generation */
 export interface GenerateUrlsOptions extends ParseOptions, CompileOptions {
-  /**
-   * Add a query string to generated url based on unknown route params.
-   */
+  /** Custom function to serialize query parameters */
   stringifyQueryParams?: (params: UrlParams) => string
-  /**
-   * Generates a unique route name based on all parent routes with the specified separator.
-   */
+  /** Separator for hierarchical route names */
   uniqueRouteNameSep?: string
 }
 
-/**
- * Create a url by route name from route path.
- */
 type GenerateUrl = (routeName: string, params?: UrlParams) => string
 
 type Keys = { [key: string]: boolean }
@@ -64,11 +261,62 @@ function cacheRoutes(
   }
 }
 
+type InferRoutes<Router> =
+  Router extends UniversalRouter<unknown, RouterContext, infer RouteDefs>
+    ? RouteDefs extends readonly unknown[]
+      ? RouteDefs
+      : never
+    : never
+
+type HasTypedRoutes<Routes extends readonly unknown[], Sep extends string> = [
+  ExtractRouteNames<Routes, '', Sep>,
+] extends [never]
+  ? false
+  : true
+
+type GenerateUrlsReturnType<Router, Sep extends string> =
+  InferRoutes<Router> extends readonly unknown[]
+    ? HasTypedRoutes<InferRoutes<Router>, Sep> extends true
+      ? TypedGenerateUrl<InferRoutes<Router>, Sep>
+      : GenerateUrl
+    : GenerateUrl
+
 /**
- * Create a function to generate urls by route names.
+ * Creates a URL generator function from a router instance.
+ * Types are automatically inferred from the router's route definitions.
+ *
+ * @example
+ * const routes = [
+ *   { name: 'home', path: '/' },
+ *   { name: 'user', path: '/users/:id' }
+ * ] as const
+ *
+ * const router = new UniversalRouter(routes)
+ * const url = generateUrls(router)
+ *
+ * url('home')              // '/'
+ * url('user', { id: '1' }) // '/users/1'
+ *
+ * @param router - Router instance to generate URLs from
+ * @param options - URL generation options
+ * @returns Type-safe URL generator function
  */
+function generateUrls<
+  Router extends UniversalRouter<
+    unknown,
+    RouterContext,
+    | Routes<unknown, RouterContext>
+    | Route<unknown, RouterContext>
+    | readonly Route<unknown, RouterContext>[]
+  >,
+  Sep extends string = '',
+>(
+  router: Router,
+  options?: TypedGenerateUrlsOptions<Sep>,
+): GenerateUrlsReturnType<Router, Sep>
+
 function generateUrls(
-  router: UniversalRouter,
+  router: UniversalRouter<unknown, RouterContext>,
   options?: GenerateUrlsOptions,
 ): GenerateUrl {
   if (!router) {

--- a/src/universal-router-sync.test.ts
+++ b/src/universal-router-sync.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect, vi, type Mock } from 'vitest'
-import UniversalRouter, { Route } from './universal-router-sync'
+import UniversalRouter, { Route, defineRoute } from './universal-router-sync'
 import type { RouteError } from './universal-router-sync'
 
 describe('UniversalRouterSync', () => {
@@ -841,5 +841,28 @@ describe('UniversalRouterSync', () => {
     const context = action.mock.calls[0]?.[0]
     expect(context).toHaveProperty('baseUrl', '')
     expect(context).toHaveProperty('route.path', ['/e', '/f'])
+  })
+
+  test('defineRoute factory pattern returns a function when called without arguments', () => {
+    const route = defineRoute<string>()
+    expect(typeof route).toBe('function')
+
+    const routeConfig = route({
+      path: '/users/:id',
+      action: (_ctx, params) => `User ${params.id}`,
+    })
+
+    expect(routeConfig.path).toBe('/users/:id')
+    expect(typeof routeConfig.action).toBe('function')
+  })
+
+  test('defineRoute returns the route when called with a route argument', () => {
+    const routeConfig = defineRoute({
+      path: '/users/:id',
+      action: (_ctx, params) => `User ${params.id}`,
+    })
+
+    expect(routeConfig.path).toBe('/users/:id')
+    expect(typeof routeConfig.action).toBe('function')
   })
 })

--- a/src/universal-router-sync.ts
+++ b/src/universal-router-sync.ts
@@ -19,130 +19,261 @@ import type {
 } from './path-to-regexp.js'
 
 /**
- * In addition to a URL path string, any arbitrary data can be passed to
- * the `router.resolve()` method, that becomes available inside action functions.
+ * Base context interface for router. Extend this to add custom properties.
+ * @example
+ * interface AppContext extends RouterContext {
+ *   user?: User
+ *   db: Database
+ * }
  */
 export interface RouterContext {
   [propName: string]: any
 }
 
+/** Context passed to resolve(), includes pathname and any custom context properties */
 export interface ResolveContext extends RouterContext {
-  /**
-   * URL which was transmitted to `router.resolve()`.
-   */
+  /** URL pathname to match against routes */
   pathname: string
 }
 
-/**
- * Params is a key/value object that represents extracted URL parameters.
- */
+/** Route parameters extracted from the URL path (e.g., { id: '123' } from '/users/:id') */
 export interface RouteParams {
   [paramName: string]: string | string[]
 }
 
+/** Return type for sync route actions. Return undefined to try children, null to skip this route entirely */
 export type RouteResultSync<T> = T | null | undefined
 
+/** Utility type that flattens intersection types for better IDE display */
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & NonNullable<unknown>
+
+/** Empty params type for routes without parameters */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type EmptyParams = {}
+
+type IsEmptyObject<T> = keyof T extends never ? true : false
+
+/** Combines extracted params with RouteParams base, applying Prettify for IDE display */
+type WithRouteParams<T> =
+  IsEmptyObject<T> extends true ? RouteParams : Prettify<T> & RouteParams
+
+type ExtractColonParam<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? { [K in Param]: string } & ExtractParams<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? { [K in Param]: string }
+      : null
+
+type ExtractWildcard<Path extends string> =
+  Path extends `${string}*${infer Wildcard}/${infer Rest}`
+    ? { [K in Wildcard]: string[] } & ExtractParams<`/${Rest}`>
+    : Path extends `${string}*${infer Wildcard}`
+      ? { [K in Wildcard]: string[] }
+      : null
+
+/**
+ * Extracts parameter types from a path string.
+ * @example
+ * ExtractParams<'/users/:id'> // { id: string }
+ * ExtractParams<'/files/*path'> // { path: string[] }
+ */
+export type ExtractParams<Path extends string> =
+  ExtractColonParam<Path> extends infer ColonResult
+    ? ColonResult extends null
+      ? ExtractWildcard<Path> extends infer WildcardResult
+        ? WildcardResult extends null
+          ? EmptyParams
+          : WildcardResult
+        : EmptyParams
+      : ColonResult
+    : EmptyParams
+
+/** Merges path params with parent params, falling back to RouteParams when both are empty */
+type TypedParams<
+  Path extends string,
+  ParentParams extends RouteParams = EmptyParams,
+> = WithRouteParams<ExtractParams<Path> & ParentParams>
+
+/**
+ * Typed route context with strongly-typed params based on the route path
+ * @example
+ * // Use with destructuring to get typed params
+ * action: ({ params }) => params.userId // params.userId is typed as string
+ */
+export interface TypedRouteContext<
+  Params extends RouteParams = RouteParams,
+  R = any,
+  C extends RouterContext = RouterContext,
+> extends Omit<RouteContext<R, C>, 'params'> {
+  /** Parameters extracted from URL, typed based on route path */
+  params: Params
+}
+
+interface TypedRoute<
+  P extends string = string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  ParentParams extends RouteParams = EmptyParams,
+> extends Omit<Route<R, C>, 'path' | 'action' | 'children'> {
+  path: P
+  action?: (
+    context: TypedRouteContext<TypedParams<P, ParentParams>, R, C>,
+    params: TypedParams<P, ParentParams>,
+  ) => RouteResultSync<R>
+  children?:
+    | TypedRoute<string, R, C, Prettify<ExtractParams<P> & ParentParams>>[]
+    | null
+}
+
+/**
+ * Helper for defining routes with typed action parameters.
+ * Use this when you want TypeScript to infer parameter types in route actions.
+ *
+ * @example
+ * // Direct usage - params.userId is typed as string
+ * defineRoute({
+ *   path: '/users/:userId',
+ *   action: (ctx, params) => fetchUser(params.userId)
+ * })
+ *
+ * // Destructured context - ctx.params.userId is also typed
+ * defineRoute({
+ *   path: '/users/:userId',
+ *   action: ({ params }) => fetchUser(params.userId)
+ * })
+ *
+ * // Factory usage for consistent result/context types
+ * const route = defineRoute<JSX.Element, AppContext>()
+ * route({ path: '/users/:id', action: (ctx, params) => <User id={params.id} /> })
+ *
+ * // With parent params inheritance
+ * defineRoute({
+ *   path: '/orgs/:orgId',
+ *   children: [
+ *     { path: '/users/:userId', action: ({ params }) => params.orgId + params.userId }
+ *   ]
+ * })
+ */
+export function defineRoute<
+  R = unknown,
+  C extends RouterContext = RouterContext,
+>(): <const P extends string, PP extends RouteParams = EmptyParams>(
+  route: TypedRoute<P, R, C, PP>,
+) => TypedRoute<P, R, C, PP>
+
+export function defineRoute<
+  const P extends string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  PP extends RouteParams = EmptyParams,
+>(route: TypedRoute<P, R, C, PP>): TypedRoute<P, R, C, PP>
+
+export function defineRoute<
+  const P extends string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  PP extends RouteParams = EmptyParams,
+>(
+  route?: TypedRoute<P, R, C, PP>,
+):
+  | TypedRoute<P, R, C, PP>
+  | (<const P2 extends string, PP2 extends RouteParams = EmptyParams>(
+      r: TypedRoute<P2, R, C, PP2>,
+    ) => TypedRoute<P2, R, C, PP2>) {
+  if (route === undefined) {
+    return <const P2 extends string, PP2 extends RouteParams = EmptyParams>(
+      r: TypedRoute<P2, R, C, PP2>,
+    ) => r
+  }
+  return route
+}
+
+/**
+ * Context passed to route actions. Includes router instance, matched route,
+ * extracted params, and next() function for delegation.
+ */
 export interface RouteContext<
   R = any,
   C extends RouterContext = RouterContext,
 > extends ResolveContext {
-  /**
-   * Current router instance.
-   */
+  /** Router instance processing this request */
   router: UniversalRouterSync<R, C>
-  /**
-   * Matched route object.
-   */
+  /** Currently matched route */
   route: Route<R, C>
-  /**
-   * Base URL path relative to the path of the current route.
-   */
+  /** Accumulated base URL from parent routes */
   baseUrl: string
-  /**
-   * Matched path.
-   */
+  /** Matched portion of the pathname */
   path: string
-  /**
-   * Matched path params.
-   */
+  /** Parameters extracted from URL */
   params: RouteParams
-  /**
-   * Middleware style function which can continue resolving.
-   */
+  /** Continue to next matching route */
   next: (resume?: boolean) => RouteResultSync<R>
 }
 
-/**
- * A Route is a singular route in your application. It contains a path, an
- * action function, and optional children which are an array of Route.
- * @template C User context that is made union with RouterContext.
- * @template R Result that every action function resolves to.
- */
+/** Route definition object */
 export interface Route<R = any, C extends RouterContext = RouterContext> {
-  /**
-   * A string, array of strings, or a regular expression. Defaults to an empty string.
-   */
+  /** URL pattern to match (e.g., '/users/:id') */
   path?: Path | Path[]
-  /**
-   * A unique string that can be used to generate the route URL.
-   */
+  /** Route name for URL generation */
   name?: string
-  /**
-   * The link to the parent route is automatically populated by the router. Useful for breadcrumbs.
-   */
+  /** Parent route reference (set internally) */
   parent?: Route<R, C> | null
-  /**
-   * An array of Route objects. Nested routes are perfect to be used in middleware routes.
-   */
+  /** Nested child routes */
   children?: Routes<R, C> | null
-  /**
-   * Action method should return anything except `null` or `undefined` to be resolved by router
-   * otherwise router will throw `Page not found` error if all matched routes returned nothing.
-   */
+  /** Handler function called when route matches */
   action?: (
     context: RouteContext<R, C>,
     params: RouteParams,
   ) => RouteResultSync<R>
-  /**
-   * The route path match function. Used for internal caching.
-   */
+  /** Compiled match function (set internally) */
   match?: MatchFunction<RouteParams>
 }
 
-/**
- * Routes is an array of type Route.
- * @template C User context that is made union with RouterContext.
- * @template R Result that every action function resolves to.
- */
+/** Array of route definitions */
 export type Routes<R = any, C extends RouterContext = RouterContext> = Route<
   R,
   C
 >[]
 
+/** Custom route resolver function signature */
 export type ResolveRoute<R = any, C extends RouterContext = RouterContext> = (
   context: RouteContext<R, C>,
   params: RouteParams,
 ) => RouteResultSync<R>
 
+/** Error with optional HTTP status code. Thrown when no route matches (status 404) */
 export type RouteError = Error & { status?: number }
 
+/** Error handler function for catching route errors */
 export type ErrorHandler<R = any> = (
   error: RouteError,
   context: ResolveContext,
 ) => RouteResultSync<R>
 
+/** Router configuration options */
 export interface RouterOptions<R = any, C extends RouterContext = RouterContext>
   extends ParseOptions, MatchOptions, PathToRegexpOptions, CompileOptions {
+  /** Custom context available in all route actions */
   context?: C
+  /** Base URL prefix for all routes */
   baseUrl?: string
+  /** Custom route resolver */
   resolveRoute?: ResolveRoute<R, C>
+  /** Handler for route errors */
   errorHandler?: ErrorHandler<R>
 }
 
+/** Internal match result containing the matched route, path, and extracted params */
 export interface RouteMatch<R = any, C extends RouterContext = RouterContext> {
+  /** Matched route object */
   route: Route<R, C>
+  /** Accumulated base URL */
   baseUrl: string
+  /** Matched path segment */
   path: string
+  /** Extracted route parameters */
   params: RouteParams
 }
 
@@ -256,17 +387,38 @@ function isChildRoute<R = any, C extends RouterContext = object>(
   return false
 }
 
-class UniversalRouterSync<R = any, C extends RouterContext = RouterContext> {
+/**
+ * Synchronous router for JavaScript web applications.
+ * Use this when route actions don't need async operations.
+ *
+ * @example
+ * const routes = [
+ *   { path: '/', action: () => 'Home' },
+ *   { path: '/users/:id', action: (ctx, params) => `User ${params.id}` }
+ * ] as const
+ *
+ * const router = new UniversalRouterSync(routes)
+ * const result = router.resolve('/users/123') // 'User 123'
+ *
+ * @typeParam R - Route action return type
+ * @typeParam C - Custom context type extending RouterContext
+ * @typeParam RouteDefs - Route definitions (inferred for type-safe URL generation)
+ */
+class UniversalRouterSync<
+  R = any,
+  C extends RouterContext = RouterContext,
+  const RouteDefs extends Routes<R, C> | Route<R, C> | readonly Route<R, C>[] =
+    | Routes<R, C>
+    | Route<R, C>,
+> {
+  /** Root route containing all route definitions */
   root: Route<R, C>
-
+  /** Base URL prefix for all routes */
   baseUrl: string
-
+  /** Router configuration options */
   options: RouterOptions<R, C>
 
-  constructor(
-    routes: Routes<R, C> | Route<R, C>,
-    options?: RouterOptions<R, C>,
-  ) {
+  constructor(routes: RouteDefs, options?: RouterOptions<R, C>) {
     if (!routes || typeof routes !== 'object') {
       throw new TypeError('Invalid routes')
     }
@@ -274,15 +426,16 @@ class UniversalRouterSync<R = any, C extends RouterContext = RouterContext> {
     this.options = { decode, ...options }
     this.baseUrl = this.options.baseUrl || ''
     this.root = Array.isArray(routes)
-      ? { path: '', children: routes, parent: null }
-      : routes
+      ? ({ path: '', children: routes, parent: null } as Route<R, C>)
+      : (routes as Route<R, C>)
     this.root.parent = null
   }
 
   /**
-   * Traverses the list of routes in the order they are defined until it finds
-   * the first route that matches provided URL path string and whose action function
-   * returns anything other than `null` or `undefined`.
+   * Traverses the route tree to find the first matching route whose action
+   * returns a non-null/undefined value.
+   * @param pathnameOrContext - URL pathname or context object with pathname
+   * @throws {RouteError} 404 error if no route matches
    */
   resolve(pathnameOrContext: string | ResolveContext): RouteResultSync<R> {
     const context: ResolveContext = {

--- a/src/universal-router.test.ts
+++ b/src/universal-router.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { describe, test, expect, vi, type Mock } from 'vitest'
-import UniversalRouter, { Route } from './universal-router'
+import UniversalRouter, { Route, defineRoute } from './universal-router'
 import type { RouteError } from './universal-router'
 
-describe('UniversalRouterSync', () => {
+describe('UniversalRouter', () => {
   test('requires routes', () => {
     // @ts-expect-error missing argument
     expect(() => new UniversalRouter()).toThrow(/Invalid routes/)
@@ -844,5 +844,28 @@ describe('UniversalRouterSync', () => {
     const context = action.mock.calls[0]?.[0]
     expect(context).toHaveProperty('baseUrl', '')
     expect(context).toHaveProperty('route.path', ['/e', '/f'])
+  })
+
+  test('defineRoute factory pattern returns a function when called without arguments', () => {
+    const route = defineRoute<string>()
+    expect(typeof route).toBe('function')
+
+    const routeConfig = route({
+      path: '/users/:id',
+      action: (_ctx, params) => `User ${params.id}`,
+    })
+
+    expect(routeConfig.path).toBe('/users/:id')
+    expect(typeof routeConfig.action).toBe('function')
+  })
+
+  test('defineRoute returns the route when called with a route argument', () => {
+    const routeConfig = defineRoute({
+      path: '/users/:id',
+      action: (_ctx, params) => `User ${params.id}`,
+    })
+
+    expect(routeConfig.path).toBe('/users/:id')
+    expect(typeof routeConfig.action).toBe('function')
   })
 })

--- a/src/universal-router.ts
+++ b/src/universal-router.ts
@@ -19,133 +19,262 @@ import type {
 } from './path-to-regexp.js'
 
 /**
- * In addition to a URL path string, any arbitrary data can be passed to
- * the `router.resolve()` method, that becomes available inside action functions.
+ * Base context interface for router. Extend this to add custom properties.
+ * @example
+ * interface AppContext extends RouterContext {
+ *   user?: User
+ *   db: Database
+ * }
  */
 export interface RouterContext {
   [propName: string]: any
 }
 
+/** Context passed to resolve(), includes pathname and any custom context properties */
 export interface ResolveContext extends RouterContext {
-  /**
-   * URL which was transmitted to `router.resolve()`.
-   */
+  /** URL pathname to match against routes */
   pathname: string
 }
 
-/**
- * Params is a key/value object that represents extracted URL parameters.
- */
+/** Route parameters extracted from the URL path (e.g., { id: '123' } from '/users/:id') */
 export interface RouteParams {
   [paramName: string]: string | string[]
 }
 
+/** Return type for route actions. Return undefined to try children, null to skip this route entirely */
 export type RouteResult<T> =
   | T
   | null
   | undefined
   | Promise<T | null | undefined>
 
+/** Utility type that flattens intersection types for better IDE display */
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & NonNullable<unknown>
+
+/** Empty params type for routes without parameters */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type EmptyParams = {}
+
+type IsEmptyObject<T> = keyof T extends never ? true : false
+
+/** Combines extracted params with RouteParams base, applying Prettify for IDE display */
+type WithRouteParams<T> =
+  IsEmptyObject<T> extends true ? RouteParams : Prettify<T> & RouteParams
+
+type ExtractColonParam<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? { [K in Param]: string } & ExtractParams<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? { [K in Param]: string }
+      : null
+
+type ExtractWildcard<Path extends string> =
+  Path extends `${string}*${infer Wildcard}/${infer Rest}`
+    ? { [K in Wildcard]: string[] } & ExtractParams<`/${Rest}`>
+    : Path extends `${string}*${infer Wildcard}`
+      ? { [K in Wildcard]: string[] }
+      : null
+
+/**
+ * Extracts parameter types from a path string.
+ * @example
+ * ExtractParams<'/users/:id'> // { id: string }
+ * ExtractParams<'/files/*path'> // { path: string[] }
+ */
+export type ExtractParams<Path extends string> =
+  ExtractColonParam<Path> extends infer ColonResult
+    ? ColonResult extends null
+      ? ExtractWildcard<Path> extends infer WildcardResult
+        ? WildcardResult extends null
+          ? EmptyParams
+          : WildcardResult
+        : EmptyParams
+      : ColonResult
+    : EmptyParams
+
+/** Merges path params with parent params, falling back to RouteParams when both are empty */
+type TypedParams<
+  Path extends string,
+  ParentParams extends RouteParams = EmptyParams,
+> = WithRouteParams<ExtractParams<Path> & ParentParams>
+
+/**
+ * Typed route context with strongly-typed params based on the route path
+ * @example
+ * // Use with destructuring to get typed params
+ * action: ({ params }) => params.userId // params.userId is typed as string
+ */
+export interface TypedRouteContext<
+  Params extends RouteParams = RouteParams,
+  R = any,
+  C extends RouterContext = RouterContext,
+> extends Omit<RouteContext<R, C>, 'params'> {
+  /** Parameters extracted from URL, typed based on route path */
+  params: Params
+}
+
+interface TypedRoute<
+  P extends string = string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  ParentParams extends RouteParams = EmptyParams,
+> extends Omit<Route<R, C>, 'path' | 'action' | 'children'> {
+  path: P
+  action?: (
+    context: TypedRouteContext<TypedParams<P, ParentParams>, R, C>,
+    params: TypedParams<P, ParentParams>,
+  ) => RouteResult<R>
+  children?:
+    | TypedRoute<string, R, C, Prettify<ExtractParams<P> & ParentParams>>[]
+    | null
+}
+
+/**
+ * Helper for defining routes with typed action parameters.
+ * Use this when you want TypeScript to infer parameter types in route actions.
+ *
+ * @example
+ * // Direct usage - params.userId is typed as string
+ * defineRoute({
+ *   path: '/users/:userId',
+ *   action: (ctx, params) => fetchUser(params.userId)
+ * })
+ *
+ * // Destructured context - ctx.params.userId is also typed
+ * defineRoute({
+ *   path: '/users/:userId',
+ *   action: ({ params }) => fetchUser(params.userId)
+ * })
+ *
+ * // Factory usage for consistent result/context types
+ * const route = defineRoute<JSX.Element, AppContext>()
+ * route({ path: '/users/:id', action: (ctx, params) => <User id={params.id} /> })
+ *
+ * // With parent params inheritance
+ * defineRoute({
+ *   path: '/orgs/:orgId',
+ *   children: [
+ *     { path: '/users/:userId', action: ({ params }) => params.orgId + params.userId }
+ *   ]
+ * })
+ */
+export function defineRoute<
+  R = unknown,
+  C extends RouterContext = RouterContext,
+>(): <const P extends string, PP extends RouteParams = EmptyParams>(
+  route: TypedRoute<P, R, C, PP>,
+) => TypedRoute<P, R, C, PP>
+
+export function defineRoute<
+  const P extends string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  PP extends RouteParams = EmptyParams,
+>(route: TypedRoute<P, R, C, PP>): TypedRoute<P, R, C, PP>
+
+export function defineRoute<
+  const P extends string,
+  R = unknown,
+  C extends RouterContext = RouterContext,
+  PP extends RouteParams = EmptyParams,
+>(
+  route?: TypedRoute<P, R, C, PP>,
+):
+  | TypedRoute<P, R, C, PP>
+  | (<const P2 extends string, PP2 extends RouteParams = EmptyParams>(
+      r: TypedRoute<P2, R, C, PP2>,
+    ) => TypedRoute<P2, R, C, PP2>) {
+  if (route === undefined) {
+    return <const P2 extends string, PP2 extends RouteParams = EmptyParams>(
+      r: TypedRoute<P2, R, C, PP2>,
+    ) => r
+  }
+  return route
+}
+
+/**
+ * Context passed to route actions. Includes router instance, matched route,
+ * extracted params, and next() function for delegation.
+ */
 export interface RouteContext<
   R = any,
   C extends RouterContext = RouterContext,
 > extends ResolveContext {
-  /**
-   * Current router instance.
-   */
+  /** Router instance processing this request */
   router: UniversalRouter<R, C>
-  /**
-   * Matched route object.
-   */
+  /** Currently matched route */
   route: Route<R, C>
-  /**
-   * Base URL path relative to the path of the current route.
-   */
+  /** Accumulated base URL from parent routes */
   baseUrl: string
-  /**
-   * Matched path.
-   */
+  /** Matched portion of the pathname */
   path: string
-  /**
-   * Matched path params.
-   */
+  /** Parameters extracted from URL */
   params: RouteParams
-  /**
-   * Middleware style function which can continue resolving.
-   */
+  /** Continue to next matching route */
   next: (resume?: boolean) => Promise<R>
 }
 
-/**
- * A Route is a singular route in your application. It contains a path, an
- * action function, and optional children which are an array of Route.
- * @template C User context that is made union with RouterContext.
- * @template R Result that every action function resolves to.
- * If the action returns a Promise, R can be the type the Promise resolves to.
- */
+/** Route definition object */
 export interface Route<R = any, C extends RouterContext = RouterContext> {
-  /**
-   * A string, array of strings, or a regular expression. Defaults to an empty string.
-   */
+  /** URL pattern to match (e.g., '/users/:id') */
   path?: Path | Path[]
-  /**
-   * A unique string that can be used to generate the route URL.
-   */
+  /** Route name for URL generation */
   name?: string
-  /**
-   * The link to the parent route is automatically populated by the router. Useful for breadcrumbs.
-   */
+  /** Parent route reference (set internally) */
   parent?: Route<R, C> | null
-  /**
-   * An array of Route objects. Nested routes are perfect to be used in middleware routes.
-   */
+  /** Nested child routes */
   children?: Routes<R, C> | null
-  /**
-   * Action method should return anything except `null` or `undefined` to be resolved by router
-   * otherwise router will throw `Page not found` error if all matched routes returned nothing.
-   */
+  /** Handler function called when route matches */
   action?: (context: RouteContext<R, C>, params: RouteParams) => RouteResult<R>
-  /**
-   * The route path match function. Used for internal caching.
-   */
+  /** Compiled match function (set internally) */
   match?: MatchFunction<RouteParams>
 }
 
-/**
- * Routes is an array of type Route.
- * @template C User context that is made union with RouterContext.
- * @template R Result that every action function resolves to.
- * If the action returns a Promise, R can be the type the Promise resolves to.
- */
+/** Array of route definitions */
 export type Routes<R = any, C extends RouterContext = RouterContext> = Route<
   R,
   C
 >[]
 
+/** Custom route resolver function signature */
 export type ResolveRoute<R = any, C extends RouterContext = RouterContext> = (
   context: RouteContext<R, C>,
   params: RouteParams,
 ) => RouteResult<R>
 
+/** Error with optional HTTP status code. Thrown when no route matches (status 404) */
 export type RouteError = Error & { status?: number }
 
+/** Error handler function for catching route errors */
 export type ErrorHandler<R = any> = (
   error: RouteError,
   context: ResolveContext,
 ) => RouteResult<R>
 
+/** Router configuration options */
 export interface RouterOptions<R = any, C extends RouterContext = RouterContext>
   extends ParseOptions, MatchOptions, PathToRegexpOptions, CompileOptions {
+  /** Custom context available in all route actions */
   context?: C
+  /** Base URL prefix for all routes */
   baseUrl?: string
+  /** Custom route resolver */
   resolveRoute?: ResolveRoute<R, C>
+  /** Handler for route errors */
   errorHandler?: ErrorHandler<R>
 }
 
+/** Internal match result containing the matched route, path, and extracted params */
 export interface RouteMatch<R = any, C extends RouterContext = RouterContext> {
+  /** Matched route object */
   route: Route<R, C>
+  /** Accumulated base URL */
   baseUrl: string
+  /** Matched path segment */
   path: string
+  /** Extracted route parameters */
   params: RouteParams
 }
 
@@ -259,17 +388,37 @@ function isChildRoute<R = any, C extends RouterContext = object>(
   return false
 }
 
-class UniversalRouter<R = any, C extends RouterContext = RouterContext> {
+/**
+ * Isomorphic router for JavaScript web applications.
+ *
+ * @example
+ * const routes = [
+ *   { path: '/', action: () => 'Home' },
+ *   { path: '/users/:id', action: (ctx, params) => `User ${params.id}` }
+ * ] as const
+ *
+ * const router = new UniversalRouter(routes)
+ * const result = await router.resolve('/users/123') // 'User 123'
+ *
+ * @typeParam R - Route action return type
+ * @typeParam C - Custom context type extending RouterContext
+ * @typeParam RouteDefs - Route definitions (inferred for type-safe URL generation)
+ */
+class UniversalRouter<
+  R = any,
+  C extends RouterContext = RouterContext,
+  const RouteDefs extends Routes<R, C> | Route<R, C> | readonly Route<R, C>[] =
+    | Routes<R, C>
+    | Route<R, C>,
+> {
+  /** Root route containing all route definitions */
   root: Route<R, C>
-
+  /** Base URL prefix for all routes */
   baseUrl: string
-
+  /** Router configuration options */
   options: RouterOptions<R, C>
 
-  constructor(
-    routes: Routes<R, C> | Route<R, C>,
-    options?: RouterOptions<R, C>,
-  ) {
+  constructor(routes: RouteDefs, options?: RouterOptions<R, C>) {
     if (!routes || typeof routes !== 'object') {
       throw new TypeError('Invalid routes')
     }
@@ -277,15 +426,16 @@ class UniversalRouter<R = any, C extends RouterContext = RouterContext> {
     this.options = { decode, ...options }
     this.baseUrl = this.options.baseUrl || ''
     this.root = Array.isArray(routes)
-      ? { path: '', children: routes, parent: null }
-      : routes
+      ? ({ path: '', children: routes, parent: null } as Route<R, C>)
+      : (routes as Route<R, C>)
     this.root.parent = null
   }
 
   /**
-   * Traverses the list of routes in the order they are defined until it finds
-   * the first route that matches provided URL path string and whose action function
-   * returns anything other than `null` or `undefined`.
+   * Traverses the route tree to find the first matching route whose action
+   * returns a non-null/undefined value.
+   * @param pathnameOrContext - URL pathname or context object with pathname
+   * @throws {RouteError} 404 error if no route matches
    */
   resolve(pathnameOrContext: string | ResolveContext): Promise<RouteResult<R>> {
     const context: ResolveContext = {


### PR DESCRIPTION
Add type-safe route definitions with automatic path parameter inference for TypeScript users.

### New Features

- **`defineRoute()` helper** - Enables TypeScript to infer parameter types in route action functions
- **`ExtractParams<Path>` type** - Extract parameter types from any path string  
- **`TypedRouteContext` interface** - Typed `context.params` for destructuring patterns
- **Parent params inheritance** - Child routes automatically inherit parent route parameters
- **Type-safe URL generation** - Compile-time validation for route names and parameters with `generateUrls()`

### Example Usage

```typescript
// Typed route actions
const route = defineRoute({
  path: '/users/:userId',
  action: (ctx, params) => fetchUser(params.userId) // params.userId typed as string
})

// Or with destructuring
const route = defineRoute({
  path: '/users/:userId',
  action: ({ params }) => fetchUser(params.userId) // also typed
})

// Type-safe URL generation
const routes = [
  { name: 'user', path: '/users/:id' }
] as const

const router = new UniversalRouter(routes)
const url = generateUrls(router)
url('user', { id: '123' }) // type-safe: route name and params validated
```

### Nested Route Parameter Inheritance

```typescript
defineRoute({
  path: '/orgs/:orgId',
  children: [
    {
      path: '/users/:userId',
      action: ({ params }) => {
        params.orgId   // typed as string (from parent)
        params.userId  // typed as string (from this route)
      }
    }
  ]
})
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.